### PR TITLE
Build `rpm` and `deb` files and create an AppImage

### DIFF
--- a/distribute_options.yaml
+++ b/distribute_options.yaml
@@ -1,0 +1,16 @@
+output: dist/
+releases:
+  - name: dev
+    jobs:
+      - name: release-dev-linux-deb
+        package:
+          platform: linux
+          target: deb
+          build_args:
+            enable_experiment: records
+      - name: release-dev-linux-rpm
+        package:
+          platform: linux
+          target: rpm
+          build_args:
+            enable_experiment: records

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -1,0 +1,22 @@
+display_name: Coppelia
+icon: assets/logo_app_icon.svg
+
+build_arch: x86_64
+
+actions:
+  - name: Run Coppelia
+    label: coppelia
+
+keywords:
+  - Music
+  - Jellyfin
+  - Streaming
+
+generic_name: Music Streaming Client
+
+categories:
+  - Multimedia
+  - Music
+
+startup_notify: true
+

--- a/linux/packaging/com.matelsky.jordan.blog.coppelia.metainfo.xml
+++ b/linux/packaging/com.matelsky.jordan.blog.coppelia.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.matelsky.jordan.blog.coppelia</id>
+
+  <name>Coppelia</name>
+  <summary>Music streaming client for Jellyfin</summary>
+
+  <metadata_license>BSL-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <description>
+    <p>
+      Coppelia is a music streaming client which can connect to Jellyfin servers.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">coppelia.desktop</launchable>
+</component>

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,0 +1,25 @@
+display_name: Coppelia
+package_name: coppelia
+
+maintainer:
+  name: Jordan Matelsky
+  email: redacted@example.com
+
+priority: optional
+
+section: x11
+
+installed_size: 76900 # Got this size from the size of the extracted tarball on your releases page
+
+icon: assets/logo_app_icon.svg
+
+dependencies:
+  - libgtk-3-dev # I think this is the correct package
+  - mpv
+
+essential: false
+
+generic_name: Music Streaming Client
+
+categories:
+  - Multimedia

--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -1,0 +1,26 @@
+display_name: Coppelia
+icon: assets/logo_app_icon.svg
+vendor: Jordan Matelsky
+packager: Josh Jeppson
+packagerEmail: redacted@example.com
+license: Apache 2.0
+url: https://github.com/j6k4m8/coppelia
+
+build_arch: x86_64
+
+requires:
+  - mpv
+  - gtk3
+
+keywords:
+  - Music
+  - Jellyfin
+  - Streaming
+
+generic_name: Music Streaming Client
+
+categories:
+  - Multimedia
+
+startup_notify: true
+


### PR DESCRIPTION
This PR enables Coppelia to be built for a host of Linux distributions, including those that use dpkg/apt, such as Debian, Ubuntu, Mint, etc., and those that use rpm, like Fedora, RHEL, Rocky, etc.

Additionally, it allows Coppelia to be compiled into an AppImage, which are portable and universally runnable across virtually all Linux distributions.

Partially fixes #86 (does not build a Flatpak)

- [x] Add config files for dpkg and rpm builds
- [x] Add FreeDesktop metainfo
- [x] Add build config for AppImage
- [ ] Create GitHub action so CI auto-builds and puts on releases page