### PR TITLE
Bump version to 0.0.18

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coppelia
 description: A refined, cross-platform Jellyfin-focused music player
 publish_to: "none"
-version: 0.0.17+17
+version: 0.0.18+18
 
 environment:
     sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Bumps the app version to 0.0.18+18 so the next release tag can build Android artifacts with the updated F-Droid-compatible release workflow.