### PR TITLE
Disable Android dependency metadata for F-Droid

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -47,6 +47,11 @@ android {
         versionName = flutter.versionName
     }
 
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     signingConfigs {
         if (hasReleaseSigning) {
             create("release") {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coppelia
 description: A refined, cross-platform Jellyfin-focused music player
 publish_to: "none"
-version: 0.0.18+18
+version: 0.0.19+19
 
 environment:
     sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Disables AGP dependency metadata in release APKs/AABs so F-Droid does not reject the developer-signed reference binaries for the extra Dependency metadata signing block.\n\nAlso bumps the app to 0.0.19+19 so fresh release assets can be published after this merges.