### PR TITLE
feat: add recently added albums shelf

### DIFF
--- a/lib/services/cache_store.dart
+++ b/lib/services/cache_store.dart
@@ -28,6 +28,7 @@ class CacheStore {
   static const _tracksKey = 'cached_playlist_tracks';
   static const _featuredKey = 'cached_featured_tracks';
   static const _albumsKey = 'cached_albums';
+  static const _recentlyAddedAlbumsKey = 'cached_recently_added_albums';
   static const _artistsKey = 'cached_artists';
   static const _genresKey = 'cached_genres';
   static const _albumTracksKey = 'cached_album_tracks';
@@ -137,6 +138,26 @@ class CacheStore {
   Future<List<Album>> loadAlbums() async {
     final preferences = await SharedPreferences.getInstance();
     final raw = preferences.getString(_albumsKey);
+    if (raw == null || raw.isEmpty) {
+      return [];
+    }
+    final decoded = jsonDecode(raw) as List<dynamic>;
+    return decoded
+        .map((entry) => Album.fromJson(entry as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Persists the newest albums shown on the Home screen.
+  Future<void> saveRecentlyAddedAlbums(List<Album> albums) async {
+    final preferences = await SharedPreferences.getInstance();
+    final payload = albums.map((album) => album.toJson()).toList();
+    await preferences.setString(_recentlyAddedAlbumsKey, jsonEncode(payload));
+  }
+
+  /// Loads the cached newest albums shown on the Home screen.
+  Future<List<Album>> loadRecentlyAddedAlbums() async {
+    final preferences = await SharedPreferences.getInstance();
+    final raw = preferences.getString(_recentlyAddedAlbumsKey);
     if (raw == null || raw.isEmpty) {
       return [];
     }
@@ -484,6 +505,7 @@ class CacheStore {
     await preferences.remove(_tracksKey);
     await preferences.remove(_featuredKey);
     await preferences.remove(_albumsKey);
+    await preferences.remove(_recentlyAddedAlbumsKey);
     await preferences.remove(_artistsKey);
     await preferences.remove(_genresKey);
     await preferences.remove(_albumTracksKey);

--- a/lib/services/jellyfin_client.dart
+++ b/lib/services/jellyfin_client.dart
@@ -203,6 +203,36 @@ class JellyfinClient {
         .toList();
   }
 
+  /// Fetches the newest albums added to the user's Jellyfin library.
+  Future<List<Album>> fetchRecentlyAddedAlbums() async {
+    final session = _requireSession();
+    final uri = Uri.parse(
+      '${session.serverUrl}/Users/${session.userId}/Items',
+    ).replace(
+      queryParameters: {
+        'IncludeItemTypes': 'MusicAlbum',
+        'Recursive': 'true',
+        'SortBy': 'DateCreated',
+        'SortOrder': 'Descending',
+        'Limit': '12',
+        'Fields': 'ImageTags,ChildCount,AlbumArtist,AlbumArtists',
+      },
+    );
+    final response =
+        await _httpClient.get(uri, headers: _authenticatedHeaders(session));
+    if (response.statusCode != 200) {
+      throw Exception('Unable to load recently added albums.');
+    }
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final items = payload['Items'] as List<dynamic>? ?? [];
+    return items
+        .map((item) => Album.fromJellyfin(
+              item as Map<String, dynamic>,
+              serverUrl: session.serverUrl,
+            ))
+        .toList();
+  }
+
   /// Fetches artists from Jellyfin.
   Future<List<Artist>> fetchArtists() async {
     final session = _requireSession();

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -111,6 +111,7 @@ class AppState extends ChangeNotifier {
   List<Playlist> _playlists = [];
   List<MediaItem> _playlistTracks = [];
   List<MediaItem> _featuredTracks = [];
+  List<Album> _recentlyAddedAlbums = [];
   List<MediaItem> _queue = [];
   List<Album> _albums = [];
   List<Artist> _artists = [];
@@ -427,6 +428,10 @@ class AppState extends ChangeNotifier {
 
   /// Available albums.
   List<Album> get albums => List.unmodifiable(_albums);
+
+  /// Albums most recently added to the Jellyfin library.
+  List<Album> get recentlyAddedAlbums =>
+      List.unmodifiable(_recentlyAddedAlbums);
 
   /// Available artists.
   List<Artist> get artists => List.unmodifiable(_artists);

--- a/lib/state/app_state_offline.dart
+++ b/lib/state/app_state_offline.dart
@@ -1012,6 +1012,7 @@ extension AppStateOfflineExtension on AppState {
     _playlists = await _cacheStore.loadPlaylists();
     _featuredTracks = await _cacheStore.loadFeaturedTracks();
     _albums = await _cacheStore.loadAlbums();
+    _recentlyAddedAlbums = await _cacheStore.loadRecentlyAddedAlbums();
     _artists = await _cacheStore.loadArtists();
     _genres = await _cacheStore.loadGenres();
     _favoriteAlbums = await _cacheStore.loadFavoriteAlbums();
@@ -1052,6 +1053,9 @@ extension AppStateOfflineExtension on AppState {
     _featuredTracks = offlineTracks;
     _recentTracks = offlineTracks;
     _albums = offlineAlbums;
+    _recentlyAddedAlbums = _recentlyAddedAlbums
+        .where((album) => offlineAlbumIds.contains(album.id))
+        .toList();
     _artists = offlineArtists;
     _playlists = offlinePlaylists;
     final cachedFavorites = await _cacheStore.loadFavoriteTracks();

--- a/lib/state/app_state_session.dart
+++ b/lib/state/app_state_session.dart
@@ -139,6 +139,7 @@ extension AppStateSessionExtension on AppState {
     _playlistTracks = [];
     _smartListTracks = [];
     _featuredTracks = [];
+    _recentlyAddedAlbums = [];
     _playlists = [];
     _albums = [];
     _artists = [];
@@ -177,7 +178,7 @@ extension AppStateSessionExtension on AppState {
     _notify();
   }
 
-  /// Refreshes playlists and featured tracks.
+  /// Refreshes library data and Home content.
   Future<void> refreshLibrary() async {
     if (_session == null) {
       return;
@@ -206,6 +207,13 @@ extension AppStateSessionExtension on AppState {
       final featured = await _client.fetchRecentTracks();
       _featuredTracks = featured;
       await _cacheStore.saveFeaturedTracks(featured);
+      try {
+        final recentlyAddedAlbums = await _client.fetchRecentlyAddedAlbums();
+        _recentlyAddedAlbums = recentlyAddedAlbums;
+        await _cacheStore.saveRecentlyAddedAlbums(recentlyAddedAlbums);
+      } catch (_) {
+        // Keep the cached shelf when the optional Home query fails.
+      }
 
       await _loadAlbums();
       await _loadArtists();

--- a/lib/state/home_section.dart
+++ b/lib/state/home_section.dart
@@ -3,6 +3,9 @@ enum HomeSection {
   /// Featured tracks shelf.
   featured,
 
+  /// Albums most recently added to the Jellyfin library.
+  recentlyAddedAlbums,
+
   /// Recently played shelf.
   recent,
 
@@ -22,6 +25,8 @@ extension HomeSectionMetadata on HomeSection {
     switch (this) {
       case HomeSection.featured:
         return 'featured';
+      case HomeSection.recentlyAddedAlbums:
+        return 'recentlyAddedAlbums';
       case HomeSection.recent:
         return 'recent';
       case HomeSection.playlists:
@@ -38,6 +43,8 @@ extension HomeSectionMetadata on HomeSection {
     switch (this) {
       case HomeSection.featured:
         return 'Featured';
+      case HomeSection.recentlyAddedAlbums:
+        return 'Recently added albums';
       case HomeSection.recent:
         return 'Recently played';
       case HomeSection.playlists:
@@ -54,6 +61,8 @@ extension HomeSectionMetadata on HomeSection {
     switch (this) {
       case HomeSection.featured:
         return 'Show the curated track shelf.';
+      case HomeSection.recentlyAddedAlbums:
+        return 'Show albums most recently added to your library.';
       case HomeSection.recent:
         return 'Show your recently played shelf.';
       case HomeSection.playlists:

--- a/lib/state/home_shelf_layout.dart
+++ b/lib/state/home_shelf_layout.dart
@@ -1,4 +1,4 @@
-/// Layout styles for featured/recent home shelves.
+/// Layout styles for media shelves on Home.
 enum HomeShelfLayout {
   /// Horizontal scroller layout.
   whooshy,

--- a/lib/ui/widgets/library_overview.dart
+++ b/lib/ui/widgets/library_overview.dart
@@ -10,8 +10,11 @@ import '../../state/layout_density.dart';
 import '../../state/library_view.dart';
 import '../../core/color_tokens.dart';
 import '../../core/formatters.dart';
+import '../../models/album.dart';
 import '../../models/media_item.dart';
+import 'album_context_menu.dart';
 import 'featured_track_card.dart';
+import 'library_card.dart';
 import 'media_card.dart';
 import 'playlist_tile.dart';
 import 'section_header.dart';
@@ -241,6 +244,73 @@ class LibraryOverview extends StatelessWidget {
       );
     }
 
+    Widget buildAlbumShelf({required List<Album> albums}) {
+      Widget buildAlbumCard(Album album) => LibraryCard(
+            title: album.name,
+            subtitle: album.artistName,
+            imageUrl: album.imageUrl,
+            icon: Icons.album,
+            onTap: () => state.selectAlbum(album),
+            onSubtitleTap: canLinkArtist(album)
+                ? () => state.selectArtistByName(album.artistName)
+                : null,
+            onContextMenu: (position) =>
+                showAlbumContextMenu(context, position, album, state),
+          );
+
+      if (state.homeShelfLayout == HomeShelfLayout.grid) {
+        return Padding(
+          padding: sectionPadding(),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final targetWidth = space(170).clamp(130.0, 220.0);
+              const aspectRatio = 0.82;
+              final columns = math.max(
+                2,
+                GridMetrics.fromWidth(
+                  width: constraints.maxWidth,
+                  itemAspectRatio: aspectRatio,
+                  itemMinWidth: targetWidth,
+                  spacing: space(12),
+                ).columns,
+              );
+              final maxItems = math.min(
+                albums.length,
+                columns * state.homeShelfGridRows,
+              );
+              final displayedAlbums = albums.take(maxItems).toList();
+              return AdaptiveGrid(
+                itemCount: displayedAlbums.length,
+                aspectRatio: aspectRatio,
+                spacing: space(12),
+                targetMinWidth: targetWidth,
+                columns: columns,
+                itemBuilder: (context, index) =>
+                    buildAlbumCard(displayedAlbums[index]),
+              );
+            },
+          ),
+        );
+      }
+
+      return Padding(
+        padding: leftPadding(),
+        child: SizedBox(
+          height: space(210).clamp(160.0, 240.0),
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: EdgeInsets.zero,
+            itemCount: albums.length,
+            separatorBuilder: (_, __) => SizedBox(width: space(16)),
+            itemBuilder: (context, index) => SizedBox(
+              width: space(155).clamp(130.0, 190.0),
+              child: buildAlbumCard(albums[index]),
+            ),
+          ),
+        ),
+      );
+    }
+
     final builders = <HomeSection, void Function()>{
       HomeSection.featured: () {
         if (!state.isHomeSectionVisible(HomeSection.featured)) {
@@ -281,6 +351,30 @@ class LibraryOverview extends StatelessWidget {
                 ? null
                 : () => state.selectAlbumById(track.albumId!),
           ),
+        ]);
+      },
+      HomeSection.recentlyAddedAlbums: () {
+        final albums = state.recentlyAddedAlbums;
+        if (!state.isHomeSectionVisible(HomeSection.recentlyAddedAlbums) ||
+            albums.isEmpty) {
+          return;
+        }
+        addSection([
+          Padding(
+            padding: sectionPadding(),
+            child: SectionHeader(
+              title: 'Recently added albums',
+              action: Text(
+                '${albums.length} albums',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: ColorTokens.textSecondary(context)),
+              ),
+            ),
+          ),
+          SizedBox(height: space(16)),
+          buildAlbumShelf(albums: albums),
         ]);
       },
       HomeSection.recent: () {

--- a/test/app_state_playlist_offline_test.dart
+++ b/test/app_state_playlist_offline_test.dart
@@ -248,6 +248,10 @@ void main() {
         .thenAnswer((_) async => const <MediaItem>[]);
     when(() => cacheStore.saveRecentTracks(any())).thenAnswer((_) async {});
     when(() => cacheStore.saveFeaturedTracks(any())).thenAnswer((_) async {});
+    when(() => client.fetchRecentlyAddedAlbums())
+        .thenAnswer((_) async => const <Album>[]);
+    when(() => cacheStore.saveRecentlyAddedAlbums(any()))
+        .thenAnswer((_) async {});
     when(() => client.fetchAlbums()).thenAnswer((_) async => const <Album>[]);
     when(() => cacheStore.saveAlbums(any())).thenAnswer((_) async {});
     when(() => client.fetchArtists()).thenAnswer((_) async => const <Artist>[]);
@@ -266,6 +270,73 @@ void main() {
   }
 
   group('AppState session', () {
+    test('signIn loads and caches recently added albums', () async {
+      final cacheStore = _MockCacheStore();
+      final client = _MockJellyfinClient();
+      final playback = _MockPlaybackController();
+      final sessionStore = _MockSessionStore();
+      final settingsStore = _MockSettingsStore();
+      final state = buildState(
+        cacheStore: cacheStore,
+        client: client,
+        playback: playback,
+        sessionStore: sessionStore,
+        settingsStore: settingsStore,
+      );
+      addTearDown(state.dispose);
+      stubSignedInRefresh(
+        cacheStore: cacheStore,
+        client: client,
+        sessionStore: sessionStore,
+      );
+      final albums = [_album('new')];
+      when(() => client.fetchRecentlyAddedAlbums())
+          .thenAnswer((_) async => albums);
+
+      final signedIn = await state.signIn(
+        serverUrl: 'https://example.com',
+        username: 'user',
+        password: 'password',
+      );
+
+      expect(signedIn, isTrue);
+      expect(state.recentlyAddedAlbums, albums);
+      verify(() => cacheStore.saveRecentlyAddedAlbums(albums)).called(1);
+    });
+
+    test('signIn succeeds when the optional recent album shelf fails',
+        () async {
+      final cacheStore = _MockCacheStore();
+      final client = _MockJellyfinClient();
+      final playback = _MockPlaybackController();
+      final sessionStore = _MockSessionStore();
+      final settingsStore = _MockSettingsStore();
+      final state = buildState(
+        cacheStore: cacheStore,
+        client: client,
+        playback: playback,
+        sessionStore: sessionStore,
+        settingsStore: settingsStore,
+      );
+      addTearDown(state.dispose);
+      stubSignedInRefresh(
+        cacheStore: cacheStore,
+        client: client,
+        sessionStore: sessionStore,
+      );
+      when(() => client.fetchRecentlyAddedAlbums())
+          .thenThrow(StateError('unsupported sort'));
+
+      final signedIn = await state.signIn(
+        serverUrl: 'https://example.com',
+        username: 'user',
+        password: 'password',
+      );
+
+      expect(signedIn, isTrue);
+      expect(state.recentlyAddedAlbums, isEmpty);
+    });
+
     test('signOut clears offline audio state for the previous account',
         () async {
       final cacheStore = _MockCacheStore();

--- a/test/cache_store_test.dart
+++ b/test/cache_store_test.dart
@@ -5,6 +5,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import 'package:coppelia/models/album.dart';
 import 'package:coppelia/models/media_item.dart';
 import 'package:coppelia/models/playback_resume_state.dart';
 import 'package:coppelia/models/playlist.dart';
@@ -55,6 +56,27 @@ void main() {
 
     expect(restored, hasLength(1));
     expect(restored.first.title, 'Evergreen');
+  });
+
+  test('cache store saves and restores recently added albums', () async {
+    SharedPreferences.setMockInitialValues({});
+    final cacheStore = CacheStore();
+    const albums = [
+      Album(
+        id: 'album-1',
+        name: 'New Record',
+        artistName: 'Studio Band',
+        trackCount: 10,
+        imageUrl: 'https://demo.jellyfin.org/Items/album-1/Images/Primary',
+      ),
+    ];
+
+    await cacheStore.saveRecentlyAddedAlbums(albums);
+    final restored = await cacheStore.loadRecentlyAddedAlbums();
+
+    expect(restored, hasLength(1));
+    expect(restored.single.id, 'album-1');
+    expect(restored.single.name, 'New Record');
   });
 
   test('media item cache migration strips legacy api key from stream URL', () {

--- a/test/jellyfin_client_test.dart
+++ b/test/jellyfin_client_test.dart
@@ -114,6 +114,57 @@ void main() {
     expect(headers, isNot(contains('X-Emby-Token')));
   });
 
+  test('fetchRecentlyAddedAlbums requests newest album records', () async {
+    final client = _MockHttpClient();
+    final jellyfin = JellyfinClient(httpClient: client);
+    jellyfin.updateSession(
+      const AuthSession(
+        accessToken: 'token',
+        serverUrl: 'https://demo.jellyfin.org',
+        userId: 'user-1',
+        userName: 'Jordan',
+      ),
+    );
+    when(
+      () => client.get(
+        any(),
+        headers: any(named: 'headers'),
+      ),
+    ).thenAnswer(
+      (_) async => http.Response(
+        jsonEncode({
+          'Items': [
+            {
+              'Id': 'album-1',
+              'Name': 'New Record',
+              'AlbumArtist': 'Studio Band',
+              'ChildCount': 10,
+              'ImageTags': {'Primary': 'cover'},
+            },
+          ],
+        }),
+        200,
+      ),
+    );
+
+    final albums = await jellyfin.fetchRecentlyAddedAlbums();
+
+    expect(albums, hasLength(1));
+    expect(albums.single.name, 'New Record');
+    expect(albums.single.artistName, 'Studio Band');
+    final uri = verify(
+      () => client.get(
+        captureAny(),
+        headers: any(named: 'headers'),
+      ),
+    ).captured.single as Uri;
+    expect(uri.queryParameters['IncludeItemTypes'], 'MusicAlbum');
+    expect(uri.queryParameters['SortBy'], 'DateCreated');
+    expect(uri.queryParameters['SortOrder'], 'Descending');
+    expect(uri.queryParameters['Limit'], '12');
+    expect(uri.queryParameters['Recursive'], 'true');
+  });
+
   test('addToPlaylist uses the current Jellyfin query API', () async {
     final client = _MockHttpClient();
     final jellyfin = JellyfinClient(httpClient: client);

--- a/test/settings_store_test.dart
+++ b/test/settings_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -42,6 +44,24 @@ void main() {
     expect(visibility[HomeSection.featured], isTrue);
     expect(visibility[HomeSection.recent], isFalse);
     expect(visibility[HomeSection.playlists], isTrue);
+    expect(visibility[HomeSection.recentlyAddedAlbums], isTrue);
+  });
+
+  test('settings store appends new home sections to saved ordering', () async {
+    SharedPreferences.setMockInitialValues({
+      'settings_home_section_order': jsonEncode([
+        'featured',
+        'recent',
+        'playlists',
+        'jumpIn',
+        'smartLists',
+      ]),
+    });
+    final store = SettingsStore();
+
+    final order = await store.loadHomeSectionOrder();
+
+    expect(order.last, HomeSection.recentlyAddedAlbums);
   });
 
   test('settings store saves sidebar visibility', () async {


### PR DESCRIPTION
add a Home shelf for albums most recently added to Jellyfin, and expose the shelf through the existing Home section visibility, ordering, and layout settings
