### PR TITLE
Prepare v0.1.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,16 @@ jobs:
       - name: Build Linux packages
         run: fastforge release --name dev
 
+      - name: Create stable Linux release assets
+        run: |
+          appimage=$(find dist -type f -name '*.AppImage' -print -quit)
+          deb=$(find dist -type f -name '*.deb' -print -quit)
+          rpm=$(find dist -type f -name '*.rpm' -print -quit)
+          test -n "$appimage" && test -n "$deb" && test -n "$rpm"
+          cp "$appimage" Coppelia-linux.AppImage
+          cp "$deb" Coppelia-linux.deb
+          cp "$rpm" Coppelia-linux.rpm
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -262,6 +272,9 @@ jobs:
           if-no-files-found: error
           path: |
             Coppelia-linux.tar.gz
+            Coppelia-linux.AppImage
+            Coppelia-linux.deb
+            Coppelia-linux.rpm
             dist/**
 
       - name: Create GitHub release
@@ -271,4 +284,7 @@ jobs:
           generate_release_notes: true
           files: |
             Coppelia-linux.tar.gz
+            Coppelia-linux.AppImage
+            Coppelia-linux.deb
+            Coppelia-linux.rpm
             dist/**

--- a/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,0 +1,5 @@
+What's new in 0.1.2
+
+* Added a Recently Added Albums shelf to Home.
+* Made library browsing more reliable by paginating server requests.
+* Made back-navigation less crazymode.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coppelia
 description: A refined, cross-platform Jellyfin-focused music player
 publish_to: "none"
-version: 0.1.1+21
+version: 0.1.2+22
 
 environment:
     sdk: ">=3.3.0 <4.0.0"

--- a/website/index.html
+++ b/website/index.html
@@ -619,16 +619,16 @@
           <h3><i class="fa-brands fa-linux"></i> Linux packages</h3>
           <div class="download-options">
             <a class="btn btn-primary"
-              href="https://github.com/j6k4m8/coppelia/releases/download/v0.0.15/coppelia-0.0.15%2B15-linux.AppImage"
+              href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-linux.AppImage"
               target="_blank" rel="noreferrer">AppImage</a>
             <a class="btn btn-ghost"
-              href="https://github.com/j6k4m8/coppelia/releases/download/v0.0.15/coppelia-0.0.15%2B15-linux.deb"
+              href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-linux.deb"
               target="_blank" rel="noreferrer">.deb</a>
             <a class="btn btn-ghost"
-              href="https://github.com/j6k4m8/coppelia/releases/download/v0.0.15/coppelia-0.0.15%2B15-linux.rpm"
+              href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-linux.rpm"
               target="_blank" rel="noreferrer">.rpm</a>
             <a class="btn btn-ghost"
-              href="https://github.com/j6k4m8/coppelia/releases/download/v0.0.15/Coppelia-linux.tar.gz" target="_blank"
+              href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-linux.tar.gz" target="_blank"
               rel="noreferrer">tar.gz</a>
           </div>
           <p>Pick the package that matches your distro. AppImage is the simplest cross-distro option.</p>
@@ -638,8 +638,9 @@
         <div class="download-card">
           <h3><i class="fa-brands fa-android"></i> Android</h3>
           <a class="btn btn-primary"
-            href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-android.apk" target="_blank"
+            href="https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-android-arm64-v8a.apk" target="_blank"
             rel="noreferrer"><i class="fa-brands fa-android"></i> Download for Android</a>
+          <p>For most modern Android phones. Other architectures are available in each release.</p>
           <p>Enable "Install unknown apps" for your browser.</p>
           <p><strong>Note:</strong> F-Droid listing is planned.</p>
         </div>
@@ -718,8 +719,8 @@
 
       const links = {
         macos: 'https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-macos.zip',
-        linux: 'https://github.com/j6k4m8/coppelia/releases/download/v0.0.15/coppelia-0.0.15%2B15-linux.AppImage',
-        android: 'https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-android.apk',
+        linux: 'https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-linux.AppImage',
+        android: 'https://github.com/j6k4m8/coppelia/releases/latest/download/Coppelia-android-arm64-v8a.apk',
         ios: '#download' // Scroll to iOS explanation
       };
 


### PR DESCRIPTION
Gets 0.1.2 ready to ship, with the F-Droid notes and download links finally pointing at current builds.