### PR TITLE
Create release notes once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,6 @@ jobs:
           name: Coppelia-macos
           path: Coppelia-macos.zip
 
-      - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: Coppelia-macos.zip
-
   build-ios:
     runs-on: macos-latest
     steps:
@@ -79,13 +72,6 @@ jobs:
         with:
           name: Coppelia-ios-simulator
           path: Coppelia-ios-simulator.zip
-
-      - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: Coppelia-ios-simulator.zip
 
   build-android:
     runs-on: ubuntu-latest
@@ -193,17 +179,6 @@ jobs:
             Coppelia-android-arm64-v8a.apk
             Coppelia-android-x86_64.apk
 
-      - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            Coppelia-android.aab
-            Coppelia-android-armeabi-v7a.apk
-            Coppelia-android-arm64-v8a.apk
-            Coppelia-android-x86_64.apk
-
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -277,14 +252,23 @@ jobs:
             Coppelia-linux.rpm
             dist/**
 
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build-macos
+      - build-ios
+      - build-android
+      - build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
       - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            Coppelia-linux.tar.gz
-            Coppelia-linux.AppImage
-            Coppelia-linux.deb
-            Coppelia-linux.rpm
-            dist/**
+          files: release-assets/**/*


### PR DESCRIPTION
Stops the release jobs from all adding the same GitHub notes.